### PR TITLE
ansible: add ansible-core to the toolkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 # Install Ansible
 # Docs: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip
 ARG ANSIBLE_VERSION=2.16.4
-RUN python3 -m pip install --user ansible==${ANSIBLE_VERSION}
+RUN python3 -m pip install --user ansible-core==${ANSIBLE_VERSION}
 
 # Cleanup
 RUN apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,11 @@ RUN curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python3.11 get-pip.py && \
     rm get-pip.py
 
+# Install Ansible
+# Docs: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip
+ARG ANSIBLE_VERSION=2.16.4
+RUN python3 -m pip install --user ansible==${ANSIBLE_VERSION}
+
 # Cleanup
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,7 @@ RUN curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 # Install Ansible
 # Docs: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip
 ARG ANSIBLE_VERSION=2.16.4
-RUN python3 -m pip install --user ansible-core==${ANSIBLE_VERSION}
+RUN python3 -m pip install ansible-core==${ANSIBLE_VERSION}
 
 # Cleanup
 RUN apt-get clean && \

--- a/scripts/docker_build.sh
+++ b/scripts/docker_build.sh
@@ -1,0 +1,1 @@
+echo "To-do"


### PR DESCRIPTION
Related: #12 

## Changes

- Add ansible core

## Test log
Verify build ✔️:
```bash
PS D:\CODING\GITHUB\OPEN-SOURCE\my-project\devops-toolkit> docker run --rm devops-toolkit ansible --version    
ansible [core 2.16.4]
  config file = None
  configured module search path = ['/root/.ansible/plugins/modules', '/usr/share/ansible/plugins/modules']
  ansible python module location = /usr/local/lib/python3.11/site-packages/ansible
  ansible collection location = /root/.ansible/collections:/usr/share/ansible/collections
  executable location = /usr/local/bin/ansible
  python version = 3.11.3 (main, Feb 27 2024, 16:35:52) [GCC 11.4.0] (/usr/local/bin/python3)
  jinja version = 3.1.3
  libyaml = True
```
