### PR TITLE
docker: add terraform to the toolkit

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get install -y \
     libffi-dev \
     libsqlite3-dev \
     wget \
+    unzip \
     libbz2-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
@@ -59,6 +60,18 @@ RUN curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 # Docs: https://docs.ansible.com/ansible/latest/installation_guide/intro_installation.html#installing-and-upgrading-ansible-with-pip
 ARG ANSIBLE_VERSION=2.16.4
 RUN python3 -m pip install ansible-core==${ANSIBLE_VERSION}
+
+# Determine the latest Terraform version
+ARG TERRAFORM_VERSION=1.7.4
+RUN mkdir /tmp/terraform_env/ && \
+    cd /tmp/terraform_env/ && \
+    curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    unzip "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
+    cp terraform_${TERRAFORM_VERSION}_linux_amd64/terraform /usr/local/bin/ && \
+    rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+
+# Display Terraform version to verify installation
+RUN terraform --version
 
 # Cleanup
 RUN apt-get clean && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,17 +61,14 @@ RUN curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 ARG ANSIBLE_VERSION=2.16.4
 RUN python3 -m pip install ansible-core==${ANSIBLE_VERSION}
 
-# Determine the latest Terraform version
+# Install Terraform
 ARG TERRAFORM_VERSION=1.7.4
 RUN mkdir /tmp/terraform_env/ && \
     cd /tmp/terraform_env/ && \
     curl -LO https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
-    unzip "terraform_${TERRAFORM_VERSION}_linux_amd64.zip" && \
-    cp terraform_${TERRAFORM_VERSION}_linux_amd64/terraform /usr/local/bin/ && \
+    unzip terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
+    cp  terraform /usr/local/bin/ && \
     rm terraform_${TERRAFORM_VERSION}_linux_amd64.zip
-
-# Display Terraform version to verify installation
-RUN terraform --version
 
 # Cleanup
 RUN apt-get clean && \


### PR DESCRIPTION
Closes: #21

## Changes
- Use `ARG TERRAFORM_VERSION=1.7.4`
- add terraform to the toolkit
- support customize version
