### PR TITLE
ci: only support manual release for now

### DIFF
--- a/.github/workflows/docker-image-main.yml
+++ b/.github/workflows/docker-image-main.yml
@@ -1,12 +1,14 @@
 name: Docker Image Main
 
 on:
-  push:
-    branches: main
-    paths:
-      - 'Dockerfile'
-      - 'scripts/*'
-      - '.github/workflows/*'
+  workflow_dispatch:
+  ## TODO: Implement the auto push later, manual release latest image for now
+  # push:
+  #   branches: main
+  #   paths:
+  #     - 'Dockerfile'
+  #     - 'scripts/*'
+  #     - '.github/workflows/*'
 
 jobs:
   buildandpush:


### PR DESCRIPTION
Closes: #65 

## Changes

ci: only support manual release for now
read the deployment pricing document and enable auto release later