### PR TITLE
ci: Update toolkit-updater.yaml using PAT

### DIFF
--- a/.github/workflows/toolkit-updater.yaml
+++ b/.github/workflows/toolkit-updater.yaml
@@ -34,7 +34,7 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PAT }}
           commit-message: 'core: update tool versions'
           committer: 'github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>'
           author: '${{ github.actor }} <${{ github.actor_id }}+${{ github.actor }}@users.noreply.github.com>'


### PR DESCRIPTION
Related: #88 
## Changes

- ci: Update toolkit-updater.yaml using PAT due to github security
