### PR TITLE
ci: rename dockerfile lint workflow

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -5,7 +5,7 @@ on:
     branches: [ "main" ]
 
 jobs:
-  build:
+  dockerfile-lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
ci: rename dockerfile lint workflow

From `build` to `dockerfile-lint`