### PR TITLE
ci: implement auto labeler for new PR and issue

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -14,9 +14,12 @@ on:
 
 jobs:
   auto_labeler:
-    runs-on: ubuntu-latest
+    # Add permission to update PR and issue labels
     permissions:
       issues: write
+      pull-requests: write
+
+    runs-on: ubuntu-latest
     steps:
       - name: Extract labels from title
         id: extract_labels

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -1,23 +1,32 @@
-name: Label issues
+name: Auto Labeler
 on:
   issues:
     types:
       - reopened
       - opened
+  pull_request:
+    types:
+      - reopened
+      - opened
+
 jobs:
-  label_issues:
+  auto_labeler:
     runs-on: ubuntu-latest
     permissions:
       issues: write
     steps:
-      - name: Extract labels from issue title
+      - name: Extract labels from title
         id: extract_labels
         run: |
           # Supported labels definition
           supported_labels=("ci" "docs" "core" "bug")
 
           # Get title
-          title="${{ github.event.issue.title }}"
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            title="${{ github.event.pull_request.title }}"
+          else
+            title="${{ github.event.issue.title }}"
+          fi
 
           # Function to parse title and return supported labels
           echo "Analyzing pull request title: '${title}'"

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -50,7 +50,7 @@ jobs:
             exit 1
           fi
 
-          echo "labels=${result}" >> $GITHUB_OUTPUT
+          echo "labels=${parsed_labels}" >> $GITHUB_OUTPUT
           echo $GITHUB_OUTPUT
       - name: Add labels to the PR/issue
         if: steps.extract_labels.outputs.labels != ''

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -52,7 +52,7 @@ jobs:
 
           echo "labels=${result}" >> $GITHUB_OUTPUT
           echo $GITHUB_OUTPUT
-      - name: Add labels to the issue
+      - name: Add labels to the PR/issue
         if: steps.extract_labels.outputs.labels != ''
         run: gh issue edit ${{ github.event.issue.number }} --add-label "${{ steps.extract_labels.outputs.labels }}"
         env:

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -24,8 +24,10 @@ jobs:
           # Get title
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             title="${{ github.event.pull_request.title }}"
+            number="${{ github.event.pull_request.number }}"
           else
             title="${{ github.event.issue.title }}"
+            number="${{ github.event.issue.number }}"
           fi
 
           # Function to parse title and return supported labels
@@ -51,9 +53,14 @@ jobs:
           fi
 
           echo "labels=${parsed_labels}" >> $GITHUB_OUTPUT
+          echo "number=${number}" >> $GITHUB_OUTPUT
           echo $GITHUB_OUTPUT
+
       - name: Add labels to the PR/issue
         if: steps.extract_labels.outputs.labels != ''
-        run: gh issue edit ${{ github.event.issue.number }} --add-label "${{ steps.extract_labels.outputs.labels }}"
+        run: gh issue edit "$NUMBER" --add-label "$LABELS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          NUMBER: ${{ steps.extract_labels.outputs.number }}
+          LABELS: ${{ steps.extract_labels.outputs.labels }}

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -25,9 +25,14 @@ jobs:
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
             title="${{ github.event.pull_request.title }}"
             number="${{ github.event.pull_request.number }}"
-          else
+            type="pr"
+          elif [[ "${{ github.event_name }}" == "issue" ]]; then
             title="${{ github.event.issue.title }}"
             number="${{ github.event.issue.number }}"
+            type="issue"
+          else
+            echo "Invalid event type: ${{ github.event_name }}"
+            exit 1
           fi
 
           # Function to parse title and return supported labels
@@ -54,13 +59,15 @@ jobs:
 
           echo "labels=${parsed_labels}" >> $GITHUB_OUTPUT
           echo "number=${number}" >> $GITHUB_OUTPUT
+          echo "type=${type}" >> $GITHUB_OUTPUT
           echo $GITHUB_OUTPUT
 
       - name: Add labels to the PR/issue
         if: steps.extract_labels.outputs.labels != ''
-        run: gh issue edit "$NUMBER" --add-label "$LABELS"
+        run: gh "$TYPE" edit "$NUMBER" --add-label "$LABELS"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           NUMBER: ${{ steps.extract_labels.outputs.number }}
+          TYPE: ${{ steps.extract_labels.outputs.type }}
           LABELS: ${{ steps.extract_labels.outputs.labels }}

--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -4,10 +4,13 @@ on:
     types:
       - reopened
       - opened
+      - edited
+
   pull_request:
     types:
       - reopened
       - opened
+      - edited
 
 jobs:
   auto_labeler:

--- a/.github/workflows/docker-image-ci.yml
+++ b/.github/workflows/docker-image-ci.yml
@@ -6,7 +6,7 @@ on:
     paths:
       - 'Dockerfile'
       - 'scripts/*'
-      - '.github/workflows/*'
+      - '.github/workflows/docker-image-ci.yml'
       - 'samples/'
 
 # Abort the previous running CI workflow in the same pull request

--- a/.github/workflows/issue-labeler.yml
+++ b/.github/workflows/issue-labeler.yml
@@ -1,0 +1,50 @@
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Extract labels from issue title
+        id: extract_labels
+        run: |
+          # Supported labels definition
+          supported_labels=("ci" "docs" "core" "bug")
+
+          # Get title
+          title="${{ github.event.issue.title }}"
+
+          # Function to parse title and return supported labels
+          echo "Analyzing pull request title: '${title}'"
+
+          # Parse title and return supported labels
+          parsed_labels=""
+          for label in "${supported_labels[@]}"; do
+            if [[ $title == *"${label}"* ]]; then
+              parsed_labels="${parsed_labels}${label};"
+              echo "Added label ${label}"
+            fi
+          done
+
+          # Remove trailing semicolon if present
+          parsed_labels="${parsed_labels%;}"
+          echo "$parsed_labels"
+
+          # Main script
+          if [ -z "$title" ]; then
+            echo "Please provide a title."
+            exit 1
+          fi
+
+          echo "labels=${result}" >> $GITHUB_OUTPUT
+          echo $GITHUB_OUTPUT
+      - name: Add labels to the issue
+        if: steps.extract_labels.outputs.labels != ''
+        run: gh issue edit ${{ github.event.issue.number }} --add-label "${{ steps.extract_labels.outputs.labels }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Closes: #24 

## Changes

- ci: implement auto labeler for new PR and issue
- only works for the support labels (to avoid spamming label in this repo)
- limit the scope of docker image CI trigger to save resources
- It will run on events:
```yaml
on:
  issues:
    types:
      - reopened
      - opened
      - edited

  pull_request:
    types:
      - reopened
      - opened
      - edited
````