### PR TITLE
core: optimize the image size and build time 🔥

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,30 +11,15 @@ RUN apt-get update
 
 # Install required packages
 RUN apt-get install -y --no-install-recommends \
-    # software-properties-common \
-    # apt-transport-https \
     ca-certificates \
     curl \
     gnupg \
     lsb-release \
-    # tzdata \
     git \
     jq \
     curl \
     wget \
     unzip
-    # Dev tools
-    # build-essential \
-    # zlib1g-dev \
-    # libncurses5-dev \
-    # libgdbm-dev \
-    # libnss3-dev \
-    # libssl-dev \
-    # libreadline-dev \
-    # libffi-dev \
-    # libsqlite3-dev \
-
-    # libbz2-dev && \
 
 # Set Python version as an argument
 ARG PYTHON_VERSION=3.11

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,51 +11,40 @@ RUN apt-get update
 
 # Install required packages
 RUN apt-get install -y --no-install-recommends \
-    software-properties-common \
-    apt-transport-https \
+    # software-properties-common \
+    # apt-transport-https \
     ca-certificates \
     curl \
     gnupg \
     lsb-release \
-    tzdata \
+    # tzdata \
     git \
     jq \
     curl \
-    # Dev tools
-    build-essential \
-    zlib1g-dev \
-    libncurses5-dev \
-    libgdbm-dev \
-    libnss3-dev \
-    libssl-dev \
-    libreadline-dev \
-    libffi-dev \
-    libsqlite3-dev \
     wget \
-    unzip \
-    libbz2-dev && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+    unzip
+    # Dev tools
+    # build-essential \
+    # zlib1g-dev \
+    # libncurses5-dev \
+    # libgdbm-dev \
+    # libnss3-dev \
+    # libssl-dev \
+    # libreadline-dev \
+    # libffi-dev \
+    # libsqlite3-dev \
+
+    # libbz2-dev && \
 
 # Set Python version as an argument
-ARG PYTHON_VERSION=3.12.2
+ARG PYTHON_VERSION=3.11
 # Install Python with specified version
-RUN mkdir /tmp/python_env/ && \
-    cd /tmp/python_env/ && \
-    wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz && \
-    tar -xf Python-${PYTHON_VERSION}.tgz && \
-    cd Python-${PYTHON_VERSION} && \
-    ./configure --enable-optimizations && \
-    make -j$(nproc) && \
-    make install && \
-    # Do cleanup
-    make clean && \
-    cd / && \
-    rm -rf /tmp/python_env/
+RUN apt install -y python${PYTHON_VERSION} && \
+    ln -sf /usr/bin/python3.11 /usr/bin/python3
 
 # Install pip for Python 3.12
 RUN curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python3.12 get-pip.py && \
+    python3 get-pip.py && \
     rm get-pip.py
 
 # Install Ansible
@@ -116,7 +105,6 @@ RUN mkdir -p /etc/apt/keyrings && \
 # Cleanup
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-
 
 # Set the working directory
 WORKDIR /root

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Built on `ubuntu:22.04` base image
 
 | Name      | Version                 | Release                                                                      | Usage                                              |
 | :-------- | :---------------------- | :--------------------------------------------------------------------------- | :------------------------------------------------- |
-| Python    | PYTHON_VERSION=3.12.2   | [Check](https://www.python.org/downloads/source/)                            | [python_usage](./docs/usage/python_usage.md)       |
+| Python    | PYTHON_VERSION=3.11     | [Check](https://www.python.org/downloads/source/)                            | [python_usage](./docs/usage/python_usage.md)       |
 | Ansible   | ANSIBLE_VERSION=2.16.4  | [Check](https://api.github.com/repos/ansible/ansible/releases/latest)        | [ansible_usage](./docs/usage/ansible_usage.md)     |
 | Terraform | TERRAFORM_VERSION=1.7.5 | [Check](https://releases.hashicorp.com/terraform/)                           | [terraform_usage](./docs/usage/terraform_usage.md) |
 | Kubectl   | KUBECTL_VERSION=1.29.3  | [Check](https://dl.k8s.io/release/stable.txt)                                | [kubectl_usage](./docs/usage/kubectl_usage.md)     |

--- a/docs/build/build_toolkit_image.md
+++ b/docs/build/build_toolkit_image.md
@@ -36,7 +36,7 @@ docker build \
 ```bash
 docker build \
   --build-arg UBUNTU_VERSION=22.04 \
-  --build-arg PYTHON_VERSION=3.11.3 \
+  --build-arg PYTHON_VERSION=3.10 \
   --build-arg ANSIBLE_VERSION=2.16.3 \
   --build-arg TERRAFORM_VERSION=1.7.0 \
   --build-arg KUBECTL_VERSION=1.29.2 \

--- a/scripts/check_latest_version.py
+++ b/scripts/check_latest_version.py
@@ -38,8 +38,10 @@ class VersionParser:
         return latest_version
 
     def check_python_version(self):
-        pattern = r'Python (\d+\.\d+\.\d+)'
-        return self.check_version("Python", "https://www.python.org/downloads/", pattern)
+        # Harcoding the python version to install the python via apt (save time + image size). See issue#104
+        # We will need to manually update the pytho nversion but, 3.11 is good  so far (on Ubuntu:22.04 base image)
+        python_version = "3.11"
+        return python_version
 
     def check_kubectl_version(self):
         pattern = r'v(\d+\.\d+\.\d+)'

--- a/scripts/check_latest_version.py
+++ b/scripts/check_latest_version.py
@@ -38,8 +38,8 @@ class VersionParser:
         return latest_version
 
     def check_python_version(self):
-        # Harcoding the python version to install the python via apt (save time + image size). See issue#104
-        # We will need to manually update the pytho nversion but, 3.11 is good  so far (on Ubuntu:22.04 base image)
+        # Specifying the Python version for installation via apt (saves time and reduces image size). Refer to issue #104.
+        # While manual updates for the Python version are needed, 3.11 has been reliable so far (on Ubuntu:22.04 base image).
         python_version = "3.11"
         return python_version
 

--- a/toolkit_info.json
+++ b/toolkit_info.json
@@ -1,5 +1,5 @@
 {
-  "python3": "3.12.2",
+  "python3": "3.11",
   "ansible": "2.16.4",
   "terraform": "1.7.5",
   "kubectl": "1.29.3",


### PR DESCRIPTION
Part of: #104 

## Changes
Improve the image size and build time🔥 
- core/improve: install python with apt
- remove unnecessary build tool
- use python3.11 in the toolkit
- faster build time

Improvement result:
- size: from  `2.11 GB` -> `1.41 GB` ✔️ 
- time: from `5m` -> `53s` ⌚  