### PR TITLE
core: update tool versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,7 +38,7 @@ ARG ANSIBLE_VERSION=2.17.0
 RUN python3 -m pip install ansible-core==${ANSIBLE_VERSION}
 
 # Install Terraform
-ARG TERRAFORM_VERSION=1.8.4
+ARG TERRAFORM_VERSION=1.8.5
 RUN mkdir /tmp/terraform_env/ && \
     cd /tmp/terraform_env/ && \
     wget https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip && \
@@ -65,7 +65,7 @@ RUN mkdir /tmp/helm_env/ && \
     rm -rf /tmp/helm_env/
 
 # Install AwsCLI
-ARG AWSCLI_VERSION=2.15.62
+ARG AWSCLI_VERSION=2.16.4
 RUN mkdir /tmp/awscli_env/ && \
     cd /tmp/awscli_env/ && \
     wget "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" && \

--- a/README.md
+++ b/README.md
@@ -98,10 +98,10 @@ Built on `ubuntu:22.04` base image
 | :-------- | :---------------------- | :--------------------------------------------------------------------------- | :------------------------------------------------- |
 | Python    | PYTHON_VERSION=3.11     | [Check](https://www.python.org/downloads/source/)                            | [python_usage](./docs/usage/python_usage.md)       |
 | Ansible   | ANSIBLE_VERSION=2.17.0  | [Check](https://api.github.com/repos/ansible/ansible/releases/latest)        | [ansible_usage](./docs/usage/ansible_usage.md)     |
-| Terraform | TERRAFORM_VERSION=1.8.4 | [Check](https://releases.hashicorp.com/terraform/)                           | [terraform_usage](./docs/usage/terraform_usage.md) |
+| Terraform | TERRAFORM_VERSION=1.8.5 | [Check](https://releases.hashicorp.com/terraform/)                           | [terraform_usage](./docs/usage/terraform_usage.md) |
 | Kubectl   | KUBECTL_VERSION=1.30.1  | [Check](https://dl.k8s.io/release/stable.txt)                                | [kubectl_usage](./docs/usage/kubectl_usage.md)     |
 | Helm      | HELM_VERSION=3.15.1     | [Check](https://github.com/helm/helm/releases)                               | [helm_usage](./docs/usage/helm_usage.md)           |
-| AwsCLI    | AWSCLI_VERSION=2.15.62  | [Check](https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst)      | [awscli_usage](./docs/usage/awscli_usage.md)       |
+| AwsCLI    | AWSCLI_VERSION=2.16.4  | [Check](https://raw.githubusercontent.com/aws/aws-cli/v2/CHANGELOG.rst)      | [awscli_usage](./docs/usage/awscli_usage.md)       |
 | AzureCLI  | AZURECLI_VERSION=2.61.0 | [Check](https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli) | [azurecli_usage](./docs/usage/azurecli_usage.md)   |
 
 And more tools to be implemented...

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,8 @@
+core: update tool versions
+
+- **python3**: from 3.12 to 3.11
+- **ansible**: from 2.12.0 to 2.17.0
+- **terraform**: from 1.82.4 to 1.8.5
+- **kubectl**: from 1.32.1 to 1.30.1
+- **helm**: from 3.12.1 to 3.15.1
+- **awscli**: from 2.12.62 to 2.16.4

--- a/toolkit_info.json
+++ b/toolkit_info.json
@@ -1,9 +1,9 @@
 {
   "python3": "3.11",
   "ansible": "2.17.0",
-  "terraform": "1.8.4",
+  "terraform": "1.8.5",
   "kubectl": "1.30.1",
   "helm": "3.15.1",
-  "awscli": "2.15.62",
+  "awscli": "2.16.4",
   "azurecli": "2.61.0"
 }


### PR DESCRIPTION
core: update tool versions

- **python3**: from 3.12 to 3.11
- **ansible**: from 2.12.0 to 2.17.0
- **terraform**: from 1.82.4 to 1.8.5
- **kubectl**: from 1.32.1 to 1.30.1
- **helm**: from 3.12.1 to 3.15.1
- **awscli**: from 2.12.62 to 2.16.4
