### PR TITLE
ci: add release pipeline

### DIFF
--- a/.github/workflows/deploy-docker-image-main.yml
+++ b/.github/workflows/deploy-docker-image-main.yml
@@ -1,9 +1,14 @@
-name: Release - Docker Image Main
+name: Deploy - Docker Image Latest (main)
 
 on:
-  push:
-    tags:
-      - 'v*'
+  workflow_dispatch:
+  ## TODO: Implement the auto push later, manual release latest image for now
+  # push:
+  #   branches: main
+  #   paths:
+  #     - 'Dockerfile'
+  #     - 'scripts/*'
+  #     - '.github/workflows/*'
 
 jobs:
   buildandpush:
@@ -14,10 +19,6 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
-      - name: Extract tag name
-        id: extract_tag
-        run: echo "::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/v}"
-
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -26,27 +27,27 @@ jobs:
 
       - name: Build the Docker image
         run: |
-          docker build . --file Dockerfile --tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}"
+          docker build . --file Dockerfile --tag "devops-toolkit-merge:$GITHUB_SHA"
 
       - name: Verify tool versions
         run: |
           cd scripts
           chmod +x check_version_in_toolkit.sh
-          ./check_version_in_toolkit.sh "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "../toolkit_info.json"
+          ./check_version_in_toolkit.sh "devops-toolkit-merge:$GITHUB_SHA" "../toolkit_info.json"
 
       - name: Running Sample Tool Code
         run: |
           echo "Run sample tool code inside toolkit"
-          docker run --rm devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }} samples/run_sample.sh
+          docker run --rm devops-toolkit-merge:$GITHUB_SHA samples/run_sample.sh
 
       - name: Push Docker Image
         run: |
           SHA7=${GITHUB_SHA::7}
-          docker tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "tungbq/devops-toolkit:${{ steps.extract_tag.outputs.TAG_NAME }}"
-          docker tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "tungbq/devops-toolkit:latest"
+          docker tag "devops-toolkit-merge:$GITHUB_SHA" "tungbq/devops-toolkit:main-$SHA7"
+          docker tag "devops-toolkit-merge:$GITHUB_SHA" "tungbq/devops-toolkit:latest"
           docker images
           echo "Push image with SHA"
-          docker push "tungbq/devops-toolkit:${{ steps.extract_tag.outputs.TAG_NAME }}"
+          docker push "tungbq/devops-toolkit:main-$SHA7"
           echo "Push latest image"
           docker push "tungbq/devops-toolkit:latest"
 

--- a/.github/workflows/deploy-docker-image-release.yml
+++ b/.github/workflows/deploy-docker-image-release.yml
@@ -1,14 +1,9 @@
-name: Release - Docker Image Main
+name: Deploy - Docker Image Release
 
 on:
-  workflow_dispatch:
-  ## TODO: Implement the auto push later, manual release latest image for now
-  # push:
-  #   branches: main
-  #   paths:
-  #     - 'Dockerfile'
-  #     - 'scripts/*'
-  #     - '.github/workflows/*'
+  push:
+    tags:
+      - 'v*'
 
 jobs:
   buildandpush:
@@ -19,6 +14,10 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v4
 
+      - name: Extract tag name
+        id: extract_tag
+        run: echo "::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/v}"
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
@@ -27,27 +26,27 @@ jobs:
 
       - name: Build the Docker image
         run: |
-          docker build . --file Dockerfile --tag "devops-toolkit-merge:$GITHUB_SHA"
+          docker build . --file Dockerfile --tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}"
 
       - name: Verify tool versions
         run: |
           cd scripts
           chmod +x check_version_in_toolkit.sh
-          ./check_version_in_toolkit.sh "devops-toolkit-merge:$GITHUB_SHA" "../toolkit_info.json"
+          ./check_version_in_toolkit.sh "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "../toolkit_info.json"
 
       - name: Running Sample Tool Code
         run: |
           echo "Run sample tool code inside toolkit"
-          docker run --rm devops-toolkit-merge:$GITHUB_SHA samples/run_sample.sh
+          docker run --rm devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }} samples/run_sample.sh
 
       - name: Push Docker Image
         run: |
           SHA7=${GITHUB_SHA::7}
-          docker tag "devops-toolkit-merge:$GITHUB_SHA" "tungbq/devops-toolkit:main-$SHA7"
-          docker tag "devops-toolkit-merge:$GITHUB_SHA" "tungbq/devops-toolkit:latest"
+          docker tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "tungbq/devops-toolkit:${{ steps.extract_tag.outputs.TAG_NAME }}"
+          docker tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "tungbq/devops-toolkit:latest"
           docker images
           echo "Push image with SHA"
-          docker push "tungbq/devops-toolkit:main-$SHA7"
+          docker push "tungbq/devops-toolkit:${{ steps.extract_tag.outputs.TAG_NAME }}"
           echo "Push latest image"
           docker push "tungbq/devops-toolkit:latest"
 

--- a/.github/workflows/deploy-docker-image-release.yml
+++ b/.github/workflows/deploy-docker-image-release.yml
@@ -41,11 +41,10 @@ jobs:
 
       - name: Push Docker Image
         run: |
-          SHA7=${GITHUB_SHA::7}
           docker tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "tungbq/devops-toolkit:${{ steps.extract_tag.outputs.TAG_NAME }}"
           docker tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "tungbq/devops-toolkit:latest"
           docker images
-          echo "Push image with SHA"
+          echo "Push image with TAG_NAME"
           docker push "tungbq/devops-toolkit:${{ steps.extract_tag.outputs.TAG_NAME }}"
           echo "Push latest image"
           docker push "tungbq/devops-toolkit:latest"

--- a/.github/workflows/release-docker-image-tag.yml
+++ b/.github/workflows/release-docker-image-tag.yml
@@ -1,0 +1,59 @@
+name: Release - Docker Image Main
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  buildandpush:
+    runs-on: ubuntu-latest
+    # Docs: https://docs.github.com/en/actions/deployment/about-deployments/deploying-with-github-actions
+    environment: dockerhub
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v4
+
+      - name: Extract tag name
+        id: extract_tag
+        run: echo "::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/v}"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build the Docker image
+        run: |
+          docker build . --file Dockerfile --tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}"
+
+      - name: Verify tool versions
+        run: |
+          cd scripts
+          chmod +x check_version_in_toolkit.sh
+          ./check_version_in_toolkit.sh "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "../toolkit_info.json"
+
+      - name: Running Sample Tool Code
+        run: |
+          echo "Run sample tool code inside toolkit"
+          docker run --rm devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }} samples/run_sample.sh
+
+      - name: Push Docker Image
+        run: |
+          SHA7=${GITHUB_SHA::7}
+          docker tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "tungbq/devops-toolkit:${{ steps.extract_tag.outputs.TAG_NAME }}"
+          docker tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "tungbq/devops-toolkit:latest"
+          docker images
+          echo "Push image with SHA"
+          docker push "tungbq/devops-toolkit:${{ steps.extract_tag.outputs.TAG_NAME }}"
+          echo "Push latest image"
+          docker push "tungbq/devops-toolkit:latest"
+
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v4
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: tungbq/devops-toolkit
+          enable-url-completion: true


### PR DESCRIPTION
ci: add release pipeline
- Run on every tag `v.*` created
- Push image `tungbq/devops-toolkit:X.Y.Z` to DockerHub (with X.Y.Z is the tag version from a repo release (tag repo vX.Y.Z)