### PR TITLE
Update Dockerfile Lint workflow to trigger only on Dockerfile changes

### DIFF
--- a/.github/workflows/dockerfile-lint.yml
+++ b/.github/workflows/dockerfile-lint.yml
@@ -3,6 +3,7 @@ name: Dockerfile Lint
 on:
   pull_request:
     branches: [ "main" ]
+    paths: ["Dockerfile"]
 
 # Abort the previous running CI workflow in the same pull request
 concurrency:


### PR DESCRIPTION
Closes: #145

## Changes

- Update `dockerfile-lint.yml` workflow to trigger only on Dockerfile changes.
