### PR TITLE
Update deploy-docker-image-release.yml to replace deprecated set-output

### DIFF
--- a/.github/workflows/deploy-docker-image-release.yml
+++ b/.github/workflows/deploy-docker-image-release.yml
@@ -16,7 +16,7 @@ jobs:
 
       - name: Extract tag name
         id: extract_tag
-        run: echo "::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/v}"
+        run: echo "TAG_NAME=${GITHUB_REF#refs/tags/v}" >> $GITHUB_ENV
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -26,26 +26,26 @@ jobs:
 
       - name: Build the Docker image
         run: |
-          docker build . --file Dockerfile --tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}"
+          docker build . --file Dockerfile --tag "devops-toolkit-release:${{ env.TAG_NAME }}"
 
       - name: Verify tool versions
         run: |
           cd scripts
           chmod +x check_version_in_toolkit.sh
-          ./check_version_in_toolkit.sh "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "../toolkit_info.json"
+          ./check_version_in_toolkit.sh "devops-toolkit-release:${{ env.TAG_NAME }}" "../toolkit_info.json"
 
       - name: Running Sample Tool Code
         run: |
           echo "Run sample tool code inside toolkit"
-          docker run --rm devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }} samples/run_sample.sh
+          docker run --rm devops-toolkit-release:${{ env.TAG_NAME }} samples/run_sample.sh
 
       - name: Push Docker Image
         run: |
-          docker tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "tungbq/devops-toolkit:${{ steps.extract_tag.outputs.TAG_NAME }}"
-          docker tag "devops-toolkit-release:${{ steps.extract_tag.outputs.TAG_NAME }}" "tungbq/devops-toolkit:latest"
+          docker tag "devops-toolkit-release:${{ env.TAG_NAME }}" "tungbq/devops-toolkit:${{ env.TAG_NAME }}"
+          docker tag "devops-toolkit-release:${{ env.TAG_NAME }}" "tungbq/devops-toolkit:latest"
           docker images
           echo "Push image with TAG_NAME"
-          docker push "tungbq/devops-toolkit:${{ steps.extract_tag.outputs.TAG_NAME }}"
+          docker push "tungbq/devops-toolkit:${{ env.TAG_NAME }}"
           echo "Push latest image"
           docker push "tungbq/devops-toolkit:latest"
 


### PR DESCRIPTION
@tungbq 
Hi!
The following changes have been made. Please review them and provide your feedback.

Closes: #175 

## Changes

- `.github/workflows/deploy-docker-image-release.yml`
  -  Replaced the deprecated `set-output` command with the new `$GITHUB_ENV` method to set environment variables across steps in the workflow.


