### PR TITLE
feat: Enable toolkit container configuration reusable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,19 +92,6 @@ RUN mkdir -p /etc/apt/keyrings && \
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# # Create the configuration directories inside the container
-# RUN mkdir -p /root/.aws /root/.azure /root/.kube /root/.terraform.d/plugins /root/.config/helm /root/.ansible
-# RUN mkdir -p /config/.aws /config/.azure /config/.kube /config/.terraform.d/plugins /config/.config/helm /config/.ansible
-
-# # Set up symlinks (this assumes that the configuration folder is mounted to /config)
-# RUN ln -s /config/.aws /root/.aws && \
-#     ln -s /config/.azure /root/.azure && \
-#     ln -s /config/.kube /root/.kube && \
-#     ln -s /config/.terraform.d/plugins /root/.terraform.d/plugins && \
-#     ln -s /config/.helm /root/.config/helm && \
-#     ln -s /config/.ansible /root/.ansible && \
-#     ln -s /config/.gitconfig /root/.gitconfig
-
 # Set the working directory
 WORKDIR /root
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -92,6 +92,19 @@ RUN mkdir -p /etc/apt/keyrings && \
 RUN apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
+# # Create the configuration directories inside the container
+# RUN mkdir -p /root/.aws /root/.azure /root/.kube /root/.terraform.d/plugins /root/.config/helm /root/.ansible
+# RUN mkdir -p /config/.aws /config/.azure /config/.kube /config/.terraform.d/plugins /config/.config/helm /config/.ansible
+
+# # Set up symlinks (this assumes that the configuration folder is mounted to /config)
+# RUN ln -s /config/.aws /root/.aws && \
+#     ln -s /config/.azure /root/.azure && \
+#     ln -s /config/.kube /root/.kube && \
+#     ln -s /config/.terraform.d/plugins /root/.terraform.d/plugins && \
+#     ln -s /config/.helm /root/.config/helm && \
+#     ln -s /config/.ansible /root/.ansible && \
+#     ln -s /config/.gitconfig /root/.gitconfig
+
 # Set the working directory
 WORKDIR /root
 
@@ -102,6 +115,15 @@ RUN chmod +x /root/samples/run_sample.sh
 # Reset environment variables
 ENV DEBIAN_FRONTEND teletype
 ENV TZ=""
+
+# Copy the entrypoint script into the container
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Make the entrypoint script executable
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Set the entrypoint to the entrypoint script
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # Define the default command to run when the container starts
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -51,16 +51,16 @@ _NOTE_: In the following section, we use the latest tag in the documentation, bu
   docker run --network host -it --rm -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
   ```
 
-  _NOTE_:
-
-  - Note: You can replace `~/.devops-toolkit-config` with any desired folder path on your VM.
-  - Remove the `-v ~/.devops-toolkit-config:/config` option if you do not wish to store configurations on the host (not recommended for configuration reuse).
-
 - Use specific tag
 
   ```bash
   docker run --network host -it --rm -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:0.1.0
   ```
+
+  _NOTE_:
+
+  - Note: You can replace `~/.devops-toolkit-config` with any desired folder path on your VM.
+  - Remove the `-v ~/.devops-toolkit-config:/config` option if you do not wish to store configurations on the host (not recommended for configuration reuse).
 
 ## Demo 📺
 
@@ -121,14 +121,13 @@ Once you have the image ready, you can start using the toolkit with the followin
 
 Explore the comprehensive guide below to gain insight into the detailed utilization of every tool within the toolkit.
 
-- Preparation of Configuration Folder on the Host
-  (It's recommended to mount a config folder from the host into the container for reuse. Skip this step if you do not intend to reuse configurations.)
+- Prepare configuration folder on the Host (Skip this step if you do not intend to reuse configurations.)
 
   ```bash
   mkdir ~/.devops-toolkit-config
-  # NOTE: It's recommended to use `~/.devops-toolkit-config` but any folder name on the host can be used.
-  # For example: /tmp/.demo-config01. Update your `docker run ...` command accordingly.
   ```
+
+  _NOTE:_ We are using `~/.devops-toolkit-config` to store toolkit configurations, but you can choose any folder name on the host.
 
 - For detailed instructions on using specific tools, refer to: [**DevOps toolkit specific tool user guide**](./docs/usage/README.md)
 - For instructions on common run modes, visit [**DevOps toolkit common run mode**](./docs/usage/run_mode.md)

--- a/README.md
+++ b/README.md
@@ -43,21 +43,25 @@ _NOTE_: In the following section, we use the latest tag in the documentation, bu
 
 ## Quick start 🔥
 
-```bash
-# Use latest tag
-docker run --network host -it --rm tungbq/devops-toolkit:latest
+- Use latest tag
 
-# Use specific tag
+```bash
+docker run --network host -it --rm tungbq/devops-toolkit:latest
+```
+
+- Use specific tag
+
+```bash
 docker run --network host -it --rm tungbq/devops-toolkit:0.1.0
 ```
 
 ## Demo 📺
 
-Check out the full sample and instruction at [**samples**](./samples/)
-
 ```bash
 docker run --network host --rm tungbq/devops-toolkit:latest samples/run_sample.sh
 ```
+
+Check out the full sample and instruction at [**samples**](./samples/)
 
 ## Getting started 📖
 

--- a/README.md
+++ b/README.md
@@ -46,21 +46,26 @@ _NOTE_: In the following section, we use the latest tag in the documentation, bu
 
 - Use latest tag
 
-```bash
-# NOTE: You can replace '~/devops-toolkit-config' path with the desired config folder oin your VM
-docker run --network host -it --rm -v ~/devops-toolkit-config:/config tungbq/devops-toolkit:latest
-```
+  ```bash
+  mkdir ~/.devops-toolkit-config
+  docker run --network host -it --rm -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
+  ```
+
+  _NOTE_:
+
+  - Note: You can replace `~/.devops-toolkit-config` with any desired folder path on your VM.
+  - Remove the `-v ~/.devops-toolkit-config:/config` option if you do not wish to store configurations on the host (not recommended for configuration reuse).
 
 - Use specific tag
 
-```bash
-docker run --network host -it --rm -v ~/devops-toolkit-config:/config tungbq/devops-toolkit:0.1.0
-```
+  ```bash
+  docker run --network host -it --rm -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:0.1.0
+  ```
 
 ## Demo 📺
 
 ```bash
-docker run --network host --rm -v ~/devops-toolkit-config:/config tungbq/devops-toolkit:latest samples/run_sample.sh
+docker run --network host --rm -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest samples/run_sample.sh
 ```
 
 Check out the full sample and instruction at [**samples**](./samples/)
@@ -88,35 +93,45 @@ Once you have the image ready, you can start using the toolkit with the followin
 
 - Start devops-toolkit container
 
-```bash
-docker run --network host -it --rm -v ~/devops-toolkit-config:/config tungbq/devops-toolkit:latest
-```
+  ```bash
+  docker run --network host -it --rm -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
+  ```
 
 - Now we are in the docker container terminal, let's explore it
 
-```bash
-root@docker-desktop:~# python3 --version
-Python 3.12.2
+  ```bash
+  root@docker-desktop:~# python3 --version
+  Python 3.12.2
 
-root@docker-desktop:~# terraform --version
-Terraform v1.7.5
-on linux_amd64
+  root@docker-desktop:~# terraform --version
+  Terraform v1.7.5
+  on linux_amd64
 
-root@docker-desktop:~# kubectl version
-Client Version: v1.29.3
-Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
+  root@docker-desktop:~# kubectl version
+  Client Version: v1.29.3
+  Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
 
-root@docker-desktop:~# aws configure
-root@docker-desktop:~# az login --use-device-code
+  root@docker-desktop:~# aws configure
+  root@docker-desktop:~# az login --use-device-code
 
-# ... more command as your needed
-```
+  # ... more command as your needed
+  ```
 
-## User guide 📖
+## User Guide 📖
 
-Explore the comprehensive guide below to gain insight into the detailed utilization of every tool within the toolkit
+Explore the comprehensive guide below to gain insight into the detailed utilization of every tool within the toolkit.
 
-- [**DevOps toolkit user guide**](./docs/usage/README.md)
+- Preparation of Configuration Folder on the Host
+  (It's recommended to mount a config folder from the host into the container for reuse. Skip this step if you do not intend to reuse configurations.)
+
+  ```bash
+  mkdir ~/.devops-toolkit-config
+  # NOTE: It's recommended to use `~/.devops-toolkit-config` but any folder name on the host can be used.
+  # For example: /tmp/.demo-config01. Update your `docker run ...` command accordingly.
+  ```
+
+- For detailed instructions on using specific tools, refer to: [**DevOps toolkit specific tool user guide**](./docs/usage/README.md)
+- For instructions on common run modes, visit [**DevOps toolkit common run mode**](./docs/usage/run_mode.md)
 
 ## The DevOps Toolkit Core 🧰
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 - **Regular Updates**: Weekly checks and updates for core tools ensure the toolkit's reliability and security.
 - **Sample code**: Includes sample code demonstrating the usage of various tools available in the toolkit.
 - **Support for Build Variants**: Enables users to customize the toolkit by building it with their preferred versions of each tool.
+- **Support Configuration Reusable**: Mounts a config folder on the host to the container.This allows reusing configurations in the container, like AWS and Azure login sessions, ...
 
 ## Prerequisites 🔓
 
@@ -36,8 +37,8 @@ Below is the versioning strategy for the repository and DockerHub:
   - Repository: `vX.Y.Z`, for example: `v1.2.3`
   - DockerHub: `X.Y.Z`, for example: `1.2.3`. (Usage: `docker pull tungbq/devops-toolkit:1.2.3`)
 - Tagging description:
-  - Specific tag (e.g., v0.1.0, v0.2.3): Contains the latest tooling version and repository features at the time this repository is tagged.
-  - In addition to that, we offer the latest tag on DockerHub (latest): Contains the latest tooling version and repository features inside the toolkit, which will be built and updated on a weekly basis.
+  - Specific tag (e.g., `0.1.0`, `0.2.3`): Contains the latest tooling version and repository features at the time this repository is tagged.
+  - In addition to that, we offer the latest tag on DockerHub (`latest`): Contains the latest tooling version and repository features inside the toolkit, which will be built and updated on a weekly basis.
 
 _NOTE_: In the following section, we use the latest tag in the documentation, but you can specify your desired tag based on your needs.
 
@@ -46,19 +47,20 @@ _NOTE_: In the following section, we use the latest tag in the documentation, bu
 - Use latest tag
 
 ```bash
-docker run --network host -it --rm tungbq/devops-toolkit:latest
+# NOTE: You can replace '~/devops-toolkit-config' path with the desired config folder oin your VM
+docker run --network host -it --rm -v ~/devops-toolkit-config:/config tungbq/devops-toolkit:latest
 ```
 
 - Use specific tag
 
 ```bash
-docker run --network host -it --rm tungbq/devops-toolkit:0.1.0
+docker run --network host -it --rm -v ~/devops-toolkit-config:/config tungbq/devops-toolkit:0.1.0
 ```
 
 ## Demo 📺
 
 ```bash
-docker run --network host --rm tungbq/devops-toolkit:latest samples/run_sample.sh
+docker run --network host --rm -v ~/devops-toolkit-config:/config tungbq/devops-toolkit:latest samples/run_sample.sh
 ```
 
 Check out the full sample and instruction at [**samples**](./samples/)
@@ -87,7 +89,7 @@ Once you have the image ready, you can start using the toolkit with the followin
 - Start devops-toolkit container
 
 ```bash
-docker run --network host -it --rm tungbq/devops-toolkit:latest
+docker run --network host -it --rm -v ~/devops-toolkit-config:/config tungbq/devops-toolkit:latest
 ```
 
 - Now we are in the docker container terminal, let's explore it
@@ -103,6 +105,9 @@ on linux_amd64
 root@docker-desktop:~# kubectl version
 Client Version: v1.29.3
 Kustomize Version: v5.0.4-0.20230601165947-6ce0bf390ce3
+
+root@docker-desktop:~# aws configure
+root@docker-desktop:~# az login --use-device-code
 
 # ... more command as your needed
 ```

--- a/docs/usage/ansible_usage.md
+++ b/docs/usage/ansible_usage.md
@@ -18,7 +18,7 @@ docker exec -it my_devops_toolkit /bin/bash
 ## Use case 1: Run Ansible sample code provided in the container
 
 ```bash
-docker run --rm --network host -it tungbq/devops-toolkit:latest
+docker run --rm --network host -v ~/.devops-toolkit-config:/config -it tungbq/devops-toolkit:latest
 
 # You now in the container terminal
 ansible-playbook samples/ansible/check_os.yml
@@ -27,7 +27,7 @@ ansible-playbook samples/ansible/check_os.yml
 ## Use case 2: Clone external code inside container
 
 ```bash
-docker run --rm --network host -it tungbq/devops-toolkit:latest
+docker run --rm --network host -v ~/.devops-toolkit-config:/config -it tungbq/devops-toolkit:latest
 # You now in the container terminal
 
 # Now run your cloned script
@@ -45,7 +45,7 @@ Clone the code to the host then mount to container
 
 ```bash
 # Given that we have code somewhere in you machine
-docker run --rm -v "$(pwd)":/root/ansible_workspace --network host -it tungbq/devops-toolkit:latest
+docker run --rm -v "$(pwd)":/root/ansible_workspace --network host -v ~/.devops-toolkit-config:/config -it tungbq/devops-toolkit:latest
 # Run the ansible code as usual
 ```
 
@@ -55,7 +55,7 @@ Clone the code to the host then mount code and `.ssh` folder to container
 
 ```bash
 # Given that we have code somewhere in you machine
-docker run --rm -v ~/.ssh:/root/.ssh -v "$(pwd)":/root/ansible_workspace --network host -it tungbq/devops-toolkit:latest
+docker run --rm -v ~/.ssh:/root/.ssh -v "$(pwd)":/root/ansible_workspace --network host -v ~/.devops-toolkit-config:/config -it tungbq/devops-toolkit:latest
 # Run the ansible code as usual
 ```
 

--- a/docs/usage/ansible_usage.md
+++ b/docs/usage/ansible_usage.md
@@ -15,6 +15,10 @@ To use the existing container instead of creating one, use `docker exec` command
 docker exec -it my_devops_toolkit /bin/bash
 ```
 
+## Common Run Modes
+
+For instructions on common run modes, visit [**DevOps Toolkit Common Run Mode**](../usage/run_mode.md).
+
 ## Use case 1: Run Ansible sample code provided in the container
 
 ```bash

--- a/docs/usage/awscli_usage.md
+++ b/docs/usage/awscli_usage.md
@@ -19,6 +19,10 @@ To use the existing container instead of creating one, use `docker exec` command
 docker exec -it my_devops_toolkit /bin/bash
 ```
 
+## Common Run Modes
+
+For instructions on common run modes, visit [**DevOps Toolkit Common Run Mode**](../usage/run_mode.md).
+
 ## Use case 1: Configure credentials and list S3 bucket with awscli
 
 ```bash

--- a/docs/usage/awscli_usage.md
+++ b/docs/usage/awscli_usage.md
@@ -22,7 +22,7 @@ docker exec -it my_devops_toolkit /bin/bash
 ## Use case 1: Configure credentials and list S3 bucket with awscli
 
 ```bash
-docker run --rm --network host -it tungbq/devops-toolkit:latest
+docker run --rm --network host -it -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
 ###############################################
 # Now we are in the docker container terminal #
 ###############################################
@@ -40,16 +40,6 @@ AWS Access Key ID [None]: xxxxxxxx
 AWS Secret Access Key [None]: xxxxxxxx
 Default region name [None]: xxxxxxxx
 Default output format [None]: xxxxxxxx
-```
-
-## Use case 2: Using AWS config from the host
-
-Mount the `.aws` when running toolkit container
-
-```bash
-docker run --rm --network host -it -v ~/.aws:/root/.aws tungbq/devops-toolkit:latest
-# List bucket
-aws s3 ls
 ```
 
 ## Troubleshooting

--- a/docs/usage/azurecli_usage.md
+++ b/docs/usage/azurecli_usage.md
@@ -22,8 +22,11 @@ docker exec -it my_devops_toolkit /bin/bash
 
 ```bash
 docker run --rm -it tungbq/devops-toolkit:latest
+
+# Login with AZ CLI
+az login --use-device-code
 ## To sign in, use a web browser to open the page https://microsoft.com/devicelogin and enter the code <SHOWN_IN_SCREEN> to authenticate
-az login
+
 # List all resource groups
 az group list
 ```

--- a/docs/usage/azurecli_usage.md
+++ b/docs/usage/azurecli_usage.md
@@ -18,6 +18,10 @@ To use the existing container instead of creating one, use `docker exec` command
 docker exec -it my_devops_toolkit /bin/bash
 ```
 
+## Common Run Modes
+
+For instructions on common run modes, visit [**DevOps Toolkit Common Run Mode**](../usage/run_mode.md).
+
 ## Use case 1: Az login and run command
 
 ```bash

--- a/docs/usage/azurecli_usage.md
+++ b/docs/usage/azurecli_usage.md
@@ -21,7 +21,7 @@ docker exec -it my_devops_toolkit /bin/bash
 ## Use case 1: Az login and run command
 
 ```bash
-docker run --rm -it tungbq/devops-toolkit:latest
+docker run --rm -it -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
 
 # Login with AZ CLI
 az login --use-device-code
@@ -31,23 +31,9 @@ az login --use-device-code
 az group list
 ```
 
-## Use case 2:  Using Azure config from the host
-
-Mount the `.azure` folder from host when running toolkit container
-
-```bash
-docker run --rm -it -v ~/.azure:/root/.azure tungbq/devops-toolkit:latest
-###############################################
-# Now we are in the docker container terminal #
-###############################################
-# List all resource groups
-az group list
-```
-
 Sample Result
 
 ```bash
-➜  ~ docker run --rm -it -v ~/.azure:/root/.azure tungbq/devops-toolkit:latest
 root@f097467db632:~# az group list
 [
   {

--- a/docs/usage/helm_usage.md
+++ b/docs/usage/helm_usage.md
@@ -19,6 +19,10 @@ To use the existing container instead of creating one, use `docker exec` command
 docker exec -it my_devops_toolkit /bin/bash
 ```
 
+## Common Run Modes
+
+For instructions on common run modes, visit [**DevOps Toolkit Common Run Mode**](../usage/run_mode.md).
+
 ## Use case 1: Deploy an application with Helm
 
 ```bash

--- a/docs/usage/helm_usage.md
+++ b/docs/usage/helm_usage.md
@@ -21,10 +21,8 @@ docker exec -it my_devops_toolkit /bin/bash
 
 ## Use case 1: Deploy an application with Helm
 
-Mount the `.kube/config` file from the host to container (or other kubeconfig files you had)
-
 ```bash
-docker run --rm --network host -it -v ~/.kube/config:/root/.kube/config tungbq/devops-toolkit:latest
+docker run --rm --network host -it -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
 ###############################################
 # Now we are in the docker container terminal #
 ###############################################

--- a/docs/usage/kubectl_usage.md
+++ b/docs/usage/kubectl_usage.md
@@ -15,12 +15,12 @@ To use the existing container instead of creating one, use `docker exec` command
 docker exec -it my_devops_toolkit /bin/bash
 ```
 
-## Use case 1: Use kubeconfig from the host
+## Use case 1: Use kube config from the host
 
 Mount the `.kube/config` file from the host to container
 
 ```bash
-docker run --rm --network host -it -v ~/.kube/config:/root/.kube/config tungbq/devops-toolkit:latest
+docker run --rm --network host -it -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
 ###############################################
 # Now we are in the docker container terminal #
 ###############################################
@@ -38,7 +38,6 @@ kubectl get deployment
 Sample Result
 
 ```bash
-➜  ~ docker run --rm --network host -it -v ~/.kube/config:/root/.kube/config tungbq/devops-toolkit:latest
 root@docker-desktop:~# kubectl get nodes
 NAME                 STATUS   ROLES           AGE   VERSION
 kind-control-plane   Ready    control-plane   21m   v1.29.2

--- a/docs/usage/kubectl_usage.md
+++ b/docs/usage/kubectl_usage.md
@@ -15,6 +15,10 @@ To use the existing container instead of creating one, use `docker exec` command
 docker exec -it my_devops_toolkit /bin/bash
 ```
 
+## Common Run Modes
+
+For instructions on common run modes, visit [**DevOps Toolkit Common Run Mode**](../usage/run_mode.md).
+
 ## Use case 1: Use kube config from the host
 
 Mount the `.kube/config` file from the host to container

--- a/docs/usage/python_usage.md
+++ b/docs/usage/python_usage.md
@@ -19,7 +19,7 @@ docker exec -it my_devops_toolkit /bin/bash
 ## Use case 1: Run python sample code provided in the container
 
 ```bash
-docker run --rm --network host -it tungbq/devops-toolkit:latest
+docker run --rm --network host -it -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
   # You now in the container terminal
 python3 samples/python/rectangle_area_calculator.py
 ```
@@ -27,7 +27,7 @@ python3 samples/python/rectangle_area_calculator.py
 ## Use case 2: Clone external code inside container
 
 ```bash
-docker run --rm --network host -it tungbq/devops-toolkit:latest
+docker run --rm --network host -it -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
 # You now in the container terminal
 # Clone code
 mkdir python_workspace
@@ -48,7 +48,7 @@ Clone the code to the host then mount to container
 
 ```bash
 # Given that we have code somewhere in you machine
-docker run --rm -v "$(pwd)":/root/python_workspace --network host -it tungbq/devops-toolkit:latest
+docker run --rm -v "$(pwd)":/root/python_workspace --network host -it -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
 # Run the python code as usual
 ```
 

--- a/docs/usage/python_usage.md
+++ b/docs/usage/python_usage.md
@@ -16,6 +16,10 @@ To use the existing container instead of creating one, use `docker exec` command
 docker exec -it my_devops_toolkit /bin/bash
 ```
 
+## Common Run Modes
+
+For instructions on common run modes, visit [**DevOps Toolkit Common Run Mode**](../usage/run_mode.md).
+
 ## Use case 1: Run python sample code provided in the container
 
 ```bash

--- a/docs/usage/run_mode.md
+++ b/docs/usage/run_mode.md
@@ -10,7 +10,7 @@ Command: `docker run <RUN_OPTS> tungbq/devops-toolkit:<TAG>`, some of the common
 - `--rm`: Remove the container after it completes (Ctrl + C or container exit event).
 - `--network host`: Use the host (VM) network.
 - `--name <CONTAINER_NAME>`: Assign a name to the container (e.g: `--name demo001`).
-- `-v <ABS_PATH_ON_THE_HOST>:/config`: Mount a config folder on the host to the container. This allows reusing configurations in the container, like AWS and Azure login sessions (e.g: `-v ~/devops-toolkit-config:/config`, `-v /tmp/devops-toolkit-config-01:/config`).
+- `-v <ABS_PATH_ON_THE_HOST>:/config`: Mount a config folder on the host to the container. This allows reusing configurations in the container, like AWS and Azure login sessions (e.g: `-v ~/.devops-toolkit-config:/config`, `-v /tmp/devops-toolkit-config-01:/config`).
 
 ## Example
 
@@ -47,6 +47,6 @@ docker run --network host -it --name demo001 tungbq/devops-toolkit:latest
 - Run the image and mount the configuration from the host, and remove the container after it completes:
 
 ```bash
-mkdir -p ~/devops-toolkit-config # or other location you want to store the configuration
-docker run --network host -it --rm -v ~/devops-toolkit-config:/config tungbq/devops-toolkit:latest
+mkdir -p ~/.devops-toolkit-config # or other location you want to store the configuration
+docker run --network host -it --rm -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
 ```

--- a/docs/usage/run_mode.md
+++ b/docs/usage/run_mode.md
@@ -1,0 +1,52 @@
+# DevOps toolkit run mode
+
+The DevOps Toolkit image can be run in various modes. See [docker/container/run](https://docs.docker.com/reference/cli/docker/container/run/) for more information. Check the document below for further details.
+
+## Run option
+
+Command: `docker run <RUN_OPTS> tungbq/devops-toolkit:<TAG>`, some of the common options can be used in any combination:
+
+- `-it`: Interactive mode.
+- `--rm`: Remove the container after it completes (Ctrl + C or container exit event).
+- `--network host`: Use the host (VM) network.
+- `--name <CONTAINER_NAME>`: Assign a name to the container (e.g: `--name demo001`).
+- `-v <ABS_PATH_ON_THE_HOST>:/config`: Mount a config folder on the host to the container. This allows reusing configurations in the container, like AWS and Azure login sessions (e.g: `-v ~/devops-toolkit-config:/config`, `-v /tmp/devops-toolkit-config-01:/config`).
+
+## Example
+
+- Run the image in interactive mode:
+
+```bash
+docker run -it --rm tungbq/devops-toolkit:latest
+```
+
+- Run a specific tag of the toolkit:
+
+```bash
+docker run -it --rm tungbq/devops-toolkit:0.1.0
+```
+
+- Run the image with host network and remove the container after it completes:
+
+```bash
+docker run --network host -it --rm tungbq/devops-toolkit:latest
+```
+
+- Run the image with default configuration and keep the container:
+
+```bash
+docker run --network host -it tungbq/devops-toolkit:latest
+```
+
+- Run the image with default configuration, specify the container name, and keep the container:
+
+```bash
+docker run --network host -it --name demo001 tungbq/devops-toolkit:latest
+```
+
+- Run the image and mount the configuration from the host, and remove the container after it completes:
+
+```bash
+mkdir -p ~/devops-toolkit-config # or other location you want to store the configuration
+docker run --network host -it --rm -v ~/devops-toolkit-config:/config tungbq/devops-toolkit:latest
+```

--- a/docs/usage/terraform_usage.md
+++ b/docs/usage/terraform_usage.md
@@ -52,7 +52,7 @@ Clone the code to the host then mount to container
 
 ```bash
 # Given that we have code somewhere in you machine
-docker run --rm -v "$(pwd)":/root/terraform_workspace --network host -it tungbq/devops-toolkit:latest
+docker run --rm -v "$(pwd)":/root/terraform_workspace -v ~/.devops-toolkit-config:/config --network host -it tungbq/devops-toolkit:latest
 # Run the terraform code as usual
 ```
 

--- a/docs/usage/terraform_usage.md
+++ b/docs/usage/terraform_usage.md
@@ -18,7 +18,7 @@ docker exec -it my_devops_toolkit /bin/bash
 ## Use case 1: Run terraform sample code provided in the container
 
 ```bash
-docker run --rm --network host -it tungbq/devops-toolkit:latest
+docker run --rm --network host -it -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
 # You now in the container terminal
 #  Navigate to Terraform sample
 pushd samples/terraform/basic
@@ -34,7 +34,7 @@ popd
 ## Use case 2: Clone external code inside container
 
 ```bash
-docker run --rm --network host -it tungbq/devops-toolkit:latest
+docker run --rm --network host -it -v ~/.devops-toolkit-config:/config tungbq/devops-toolkit:latest
 # You now in the container terminal
 
 # Now run your cloned script

--- a/docs/usage/terraform_usage.md
+++ b/docs/usage/terraform_usage.md
@@ -15,6 +15,10 @@ To use the existing container instead of creating one, use `docker exec` command
 docker exec -it my_devops_toolkit /bin/bash
 ```
 
+## Common Run Modes
+
+For instructions on common run modes, visit [**DevOps Toolkit Common Run Mode**](../usage/run_mode.md).
+
 ## Use case 1: Run terraform sample code provided in the container
 
 ```bash

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+CONFIG_DIR=/config
+
+# Function to create symlink if source exists
+create_symlink() {
+    local src=$1
+    local dest=$2
+    if [ -e "$src" ]; then
+        ln -sf "$src" "$dest"
+        echo "Symlink created: $src -> $dest"
+    fi
+}
+
+# Check if the /config directory exists and is not empty
+if [ -d "$CONFIG_DIR" ] ; then
+    echo "Custom configuration directory detected. Setting up symlinks..."
+
+    # TODO: Check and only create if folder does not exist
+    # mkdir -p /root/.aws /root/.azure /root/.kube /root/.terraform.d/plugins /root/.config/helm /root/.ansible
+    mkdir -p /config/.aws \
+             /config/.azure \
+             /config/.kube \
+             /config/.terraform.d/ \
+             /config/.config/helm \
+             /config/.ansible
+
+    create_symlink "$CONFIG_DIR/.aws" "/root/.aws"
+    create_symlink "$CONFIG_DIR/.azure" "/root/.azure"
+    create_symlink "$CONFIG_DIR/.kube" "/root/.kube"
+    create_symlink "$CONFIG_DIR/.terraform.d/" "/root/.terraform.d/"
+    create_symlink "$CONFIG_DIR/.helm" "/root/.config/helm"
+    create_symlink "$CONFIG_DIR/.ansible" "/root/.ansible"
+    create_symlink "$CONFIG_DIR/.gitconfig" "/root/.gitconfig"
+else
+    echo "No custom configuration directory detected. Using default configurations..."
+fi
+
+# Execute the provided command
+exec "$@"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,36 +4,39 @@ CONFIG_DIR=/config
 
 # Function to create symlink if source exists
 create_symlink() {
-    local src=$1
-    local dest=$2
-    if [ -e "$src" ]; then
-        ln -sf "$src" "$dest"
-        echo "Symlink created: $src -> $dest"
-    fi
+  local src=$1
+  local dest=$2
+  if [ -e "$src" ]; then
+    ln -sf "$src" "$dest"
+    echo "Symlink created: $src -> $dest"
+  fi
 }
 
 # Check if the /config directory exists and is not empty
-if [ -d "$CONFIG_DIR" ] ; then
-    echo "Custom configuration directory detected. Setting up symlinks..."
+if [ -d "$CONFIG_DIR" ]; then
+  echo "Custom configuration directory detected. Setting up symlinks..."
 
-    # TODO: Check and only create if folder does not exist
-    # mkdir -p /root/.aws /root/.azure /root/.kube /root/.terraform.d/plugins /root/.config/helm /root/.ansible
-    mkdir -p /config/.aws \
-             /config/.azure \
-             /config/.kube \
-             /config/.terraform.d/ \
-             /config/.config/helm \
-             /config/.ansible
+  # TODO: Check and only create if folder does not exist
+  ## config mount point
+  mkdir -p /config/.aws \
+    /config/.azure \
+    /config/.kube \
+    /config/.terraform.d \
+    /config/.config/helm \
+    /config/.ansible
 
-    create_symlink "$CONFIG_DIR/.aws" "/root/.aws"
-    create_symlink "$CONFIG_DIR/.azure" "/root/.azure"
-    create_symlink "$CONFIG_DIR/.kube" "/root/.kube"
-    create_symlink "$CONFIG_DIR/.terraform.d/" "/root/.terraform.d/"
-    create_symlink "$CONFIG_DIR/.helm" "/root/.config/helm"
-    create_symlink "$CONFIG_DIR/.ansible" "/root/.ansible"
-    create_symlink "$CONFIG_DIR/.gitconfig" "/root/.gitconfig"
+  ## root container path
+  mkdir -p /root/.config/
+
+  create_symlink "$CONFIG_DIR/.aws" "/root/.aws"
+  create_symlink "$CONFIG_DIR/.azure" "/root/.azure"
+  create_symlink "$CONFIG_DIR/.kube" "/root/.kube"
+  create_symlink "$CONFIG_DIR/.terraform.d" "/root/.terraform.d"
+  create_symlink "$CONFIG_DIR/.config/helm" "/root/.config/helm"
+  create_symlink "$CONFIG_DIR/.ansible" "/root/.ansible"
+  create_symlink "$CONFIG_DIR/.gitconfig" "/root/.gitconfig"
 else
-    echo "No custom configuration directory detected. Using default configurations..."
+  echo "No custom configuration directory detected. Using default configurations..."
 fi
 
 # Execute the provided command


### PR DESCRIPTION
Related: #156

## Changes
Enable container configuration reusable:
- Mounts a config folder on the host to the container.
- This allows reusing configurations in the container, like AWS and Azure login sessions, ...
- Update related document
- Add entrypoint to Dockerfile
