### PR TITLE
Rename devops-toolkit to devops-toolkit-cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Use the provided execution script simplifies setup, execution and managing DevOp
 ### 1. Install
 
 ```bash
-curl -o devops-toolkit https://raw.githubusercontent.com/tungbq/devops-toolkit/main/devops-toolkit
-chmod +x devops-toolkit
-sudo mv devops-toolkit /usr/local/bin/
+curl -o devops-toolkit-cli https://raw.githubusercontent.com/tungbq/devops-toolkit/main/devops-toolkit-cli
+chmod +x devops-toolkit-cli
+sudo mv devops-toolkit-cli /usr/local/bin/
 ```
 
 ### 2. Run
@@ -39,29 +39,29 @@ sudo mv devops-toolkit /usr/local/bin/
 - Initialize the docker image, container and configuration directory:
 
 ```bash
-devops-toolkit init
-# Run 'devops-toolkit init vX.Y.Z' if you want to use specific version. E.g: devops-toolkit init 1.0.2
+devops-toolkit-cli init
+# Run 'devops-toolkit-cli init vX.Y.Z' if you want to use specific version. E.g: devops-toolkit-cli init 1.0.2
 ```
 
 - Start a shell in new container:
 
 ```bash
-devops-toolkit run
+devops-toolkit-cli run
 ```
 
 - Execute a command in the container:
 
 ```bash
-devops-toolkit run ls -la
+devops-toolkit-cli run ls -la
 ```
 
 - Access the shell:
 
 ```bash
-devops-toolkit shell
+devops-toolkit-cli shell
 ```
 
-- For more commands, use `devops-toolkit help`.
+- For more commands, use `devops-toolkit-cli help`.
 
 ## Use DevOps Toolkit with docker command directly
 

--- a/devops-toolkit-cli
+++ b/devops-toolkit-cli
@@ -207,7 +207,7 @@ init() {
 
     if docker inspect --type=container "$CONTAINER_NAME" > /dev/null 2>&1; then
         log $YELLOW "Container $CONTAINER_NAME already exists. Skipping initialization."
-        log $YELLOW "Run 'devops-toolkit cleanup' then init again if you want to re-init!"
+        log $YELLOW "Run 'devops-toolkit-cli cleanup' then init again if you want to re-init!"
     else
         log $BLUE "Initializing container with image $image..."
         pull_image "$image"


### PR DESCRIPTION
Related #207 - Improvement
This helps us separate the cli and the image name, avoid confusing