### PR TITLE
core: upgrade base image to Ubuntu 24.04 and Python to 3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,8 +40,13 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/*
 
 # Install pip for Python 3.12
+# --break-system-packages: Ubuntu 24.04 marks the system Python as
+# "externally managed" (PEP 668) and refuses plain pip installs. That
+# protection exists to stop pip from fighting apt on a general-purpose
+# system - it doesn't apply here, since this container's system Python
+# is entirely dedicated to running this toolkit.
 RUN curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
-    python3 get-pip.py && \
+    python3 get-pip.py --break-system-packages && \
     rm get-pip.py
 
 # Install Ansible
@@ -49,7 +54,7 @@ RUN curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 # transitive resolution) because older wheels bundle a vulnerable OpenSSL
 ARG ANSIBLE_VERSION=2.21.1
 ARG CRYPTOGRAPHY_VERSION=49.0.0
-RUN python3 -m pip install ansible-core==${ANSIBLE_VERSION} cryptography==${CRYPTOGRAPHY_VERSION}
+RUN python3 -m pip install --break-system-packages ansible-core==${ANSIBLE_VERSION} cryptography==${CRYPTOGRAPHY_VERSION}
 
 # Install Terraform
 ARG TERRAFORM_VERSION=1.15.8
@@ -106,7 +111,7 @@ RUN mkdir -p /etc/apt/keyrings && \
     # Use "python3 -m pip", not the "pip" console script: azure-cli's deb
     # ships that script with a shebang baked in from Microsoft's own build
     # environment (/mnt/repo/python_env/bin/python3), which doesn't exist here.
-    /opt/az/bin/python3 -m pip install --no-cache-dir --upgrade "cryptography==${CRYPTOGRAPHY_VERSION}"
+    /opt/az/bin/python3 -m pip install --no-cache-dir --break-system-packages --upgrade "cryptography==${CRYPTOGRAPHY_VERSION}"
 
 # PowerShell Installation
 ARG PS_VERSION=7.6.3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Ubuntu 22.04 base image
-ARG UBUNTU_VERSION=22.04
+# Use the official Ubuntu 24.04 base image
+ARG UBUNTU_VERSION=24.04
 FROM ubuntu:${UBUNTU_VERSION}
 
 # Set environment variables to avoid interactive installation prompts
@@ -8,8 +8,11 @@ ARG TZ=UTC
 
 # Install required packages + Python in a single layer so the apt cache
 # never lingers in the image (deleting it in a later layer does not shrink
-# the layer that downloaded it)
-ARG PYTHON_VERSION=3.11
+# the layer that downloaded it).
+# Package names below are Ubuntu 24.04 (noble)'s post 64-bit-time_t-transition
+# names: libicu74 (was libicu70), libssl3t64 (was libssl3), libgcc-s1 (was
+# libgcc1), liblttng-ust1t64 (was liblttng-ust1).
+ARG PYTHON_VERSION=3.12
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
@@ -23,12 +26,12 @@ RUN apt-get update && \
     openssh-client \
     locales \
     gss-ntlmssp \
-    libicu70 \
-    libssl3 \
+    libicu74 \
+    libssl3t64 \
     libc6 \
-    libgcc1 \
+    libgcc-s1 \
     libgssapi-krb5-2 \
-    liblttng-ust1 \
+    liblttng-ust1t64 \
     libstdc++6 \
     zlib1g \
     python${PYTHON_VERSION} && \
@@ -36,7 +39,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-# Install pip for Python 3.11
+# Install pip for Python 3.12
 RUN curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
     python3 get-pip.py && \
     rm get-pip.py
@@ -44,7 +47,7 @@ RUN curl -k https://bootstrap.pypa.io/get-pip.py -o get-pip.py && \
 # Install Ansible
 # cryptography is pinned explicitly (rather than left to ansible-core's
 # transitive resolution) because older wheels bundle a vulnerable OpenSSL
-ARG ANSIBLE_VERSION=2.19.11
+ARG ANSIBLE_VERSION=2.21.1
 ARG CRYPTOGRAPHY_VERSION=49.0.0
 RUN python3 -m pip install ansible-core==${ANSIBLE_VERSION} cryptography==${CRYPTOGRAPHY_VERSION}
 
@@ -120,7 +123,7 @@ ENV DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false \
     LANG=en_US.UTF-8 \
     PS_INSTALL_FOLDER=/opt/microsoft/powershell/$PS_INSTALL_VERSION \
     PSModuleAnalysisCachePath=/var/cache/microsoft/powershell/PSModuleAnalysisCache/ModuleAnalysisCache \
-    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-Ubuntu-22.04
+    POWERSHELL_DISTRIBUTION_CHANNEL=PSDocker-Ubuntu-24.04
 
 RUN locale-gen $LANG && update-locale && \
     export POWERSHELL_TELEMETRY_OPTOUT=1 && \

--- a/README.md
+++ b/README.md
@@ -104,12 +104,12 @@ Explore the comprehensive guide below to gain insight into the detailed utilizat
 
 ## The DevOps Toolkit Core 🧰
 
-Built on `ubuntu:22.04` base image
+Built on `ubuntu:24.04` base image
 
 | Name       | Version                 | Release                                                                      | Usage                                              |
 | :--------- | :---------------------- | :--------------------------------------------------------------------------- | :------------------------------------------------- |
-| Python     | PYTHON_VERSION=3.11     | [Check](https://www.python.org/downloads/source/)                            | [python_usage](./docs/usage/python_usage.md)       |
-| Ansible    | ANSIBLE_VERSION=2.19.11  | [Check](https://api.github.com/repos/ansible/ansible/releases/latest)        | [ansible_usage](./docs/usage/ansible_usage.md)     |
+| Python     | PYTHON_VERSION=3.12     | [Check](https://www.python.org/downloads/source/)                            | [python_usage](./docs/usage/python_usage.md)       |
+| Ansible    | ANSIBLE_VERSION=2.21.1  | [Check](https://api.github.com/repos/ansible/ansible/releases/latest)        | [ansible_usage](./docs/usage/ansible_usage.md)     |
 | Terraform  | TERRAFORM_VERSION=1.15.8 | [Check](https://releases.hashicorp.com/terraform/)                           | [terraform_usage](./docs/usage/terraform_usage.md) |
 | Kubectl    | KUBECTL_VERSION=1.36.2  | [Check](https://dl.k8s.io/release/stable.txt)                                | [kubectl_usage](./docs/usage/kubectl_usage.md)     |
 | Helm       | HELM_VERSION=3.21.3     | [Check](https://github.com/helm/helm/releases)                               | [helm_usage](./docs/usage/helm_usage.md)           |

--- a/scripts/check_latest_version.py
+++ b/scripts/check_latest_version.py
@@ -39,8 +39,9 @@ class VersionParser:
 
     def check_python_version(self):
         # Specifying the Python version for installation via apt (saves time and reduces image size). Refer to issue #104.
-        # While manual updates for the Python version are needed, 3.11 has been reliable so far (on Ubuntu:22.04 base image).
-        python_version = "3.11"
+        # Manual updates are needed here since this tracks whatever Python version ships
+        # in the pinned Ubuntu base image's apt repos (3.12 on Ubuntu:24.04).
+        python_version = "3.12"
         return python_version
 
     def check_kubectl_version(self):

--- a/toolkit_info.json
+++ b/toolkit_info.json
@@ -1,6 +1,6 @@
 {
-  "python3": "3.11",
-  "ansible": "2.19.11",
+  "python3": "3.12",
+  "ansible": "2.21.1",
   "terraform": "1.15.8",
   "kubectl": "1.36.2",
   "helm": "3.21.3",


### PR DESCRIPTION
## Summary
- Base image: `ubuntu:22.04` → `ubuntu:24.04`. Python: 3.11 → 3.12.
- Ubuntu 22.04's apt repos only go up to Python 3.11, which is what forced ansible-core to stay below 2.20 in #267 (2.20+ requires Python >=3.12). This removes that ceiling without reaching for the deadsnakes PPA that issue #104 moved away from.
- ansible-core bumped to the actual latest release, 2.21.1, now that Python 3.12 satisfies its constraint.
- Base apt package names updated for noble's 64-bit-time_t transition: `libicu70`→`libicu74`, `libssl3`→`libssl3t64`, `libgcc1`→`libgcc-s1`, `liblttng-ust1`→`liblttng-ust1t64`. Verified directly against the noble Packages indexes and cross-checked against azure-cli's own noble package `Depends` line.
- Azure CLI needed no code changes — `AZ_DIST` is already resolved dynamically via `lsb_release -cs`, and Microsoft publishes `azure-cli 2.88.0` for `noble`. PowerShell's `.deb` asset is distro-agnostic too.
- Synced `toolkit_info.json`, `README.md`, and `check_latest_version.py`'s hardcoded Python value so the automated version-checker tracks 3.12 going forward.

## Test plan
- [ ] `Docker Image CI` builds cleanly on Ubuntu 24.04 with the renamed packages
- [ ] `Trivy` gate passes (or any new findings get triaged)
- [ ] Spot-check `python3 --version`, `ansible --version`, `pwsh --version`, `az --version` inside the built image