### PR TITLE
docs: complete the Apache 2.0 copyright notice, add License section

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2024-2026 Tung Bui
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://github.com/tungbq/devops-toolkit/actions/workflows/vulnerability-scanner.yaml"><img alt="Vulnerability scan" src="https://github.com/tungbq/devops-toolkit/actions/workflows/vulnerability-scanner.yaml/badge.svg"/></a>
   <a href="https://hub.docker.com/r/tungbq/devops-toolkit"><img alt="tungbq/devops-toolkit" src="https://img.shields.io/docker/pulls/tungbq/devops-toolkit"/></a>
   <a href="https://github.com/tungbq/devops-toolkit/stargazers"><img alt="GitHub Repo stars" src="https://img.shields.io/github/stars/tungbq/devops-toolkit"/></a>
+  <a href="./LICENSE"><img alt="License" src="https://img.shields.io/github/license/tungbq/devops-toolkit"/></a>
 </p>
 
 ## Key Features
@@ -138,6 +139,10 @@ Whichever tag you pull — `latest` or a pinned `vX.Y.Z` release — you're gett
 - Looking for the issue to work on? Check the list of our open issues [**good first issue**](https://github.com/tungbq/devops-toolkit/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
 - Feel free to open a new issue if you encounter the toolkit bug or want to request more content about DevOps toolkit
 - Submit a [new issue](https://github.com/tungbq/devops-toolkit/issues/new) (🐛) if you encounter the bug/error when using this toolkit
+
+## License 📄
+
+Licensed under the [Apache License, Version 2.0](./LICENSE). You're free to use, modify, and distribute this project, including commercially, provided you retain the copyright notice and state significant changes. The license also grants an explicit patent license from contributors and includes the standard "AS IS" warranty disclaimer.
 
 ## Hit the Star! ⭐
 


### PR DESCRIPTION
## Summary
`LICENSE` already had the full Apache 2.0 text, but the copyright notice at the bottom was still the unfilled template (`Copyright [yyyy] [name of copyright owner]`), and the README never mentioned licensing at all — no section, no badge.

- Filled in the copyright notice: `Copyright 2024-2026 Tung Bui` (2024 is this repo's first commit).
- Added a License section to the README summarizing what Apache 2.0 grants/requires, plus a license badge in the header row.

No license change — Apache 2.0 already covers what most solo maintainers mean by "a license that protects me": the Section 7 warranty disclaimer, Section 8 liability limitation, and Section 3's explicit patent grant with a termination clause if someone sues you over patents in your own code. This just completes what was already there.

## Test plan
- Docs-only change, no build/CI impact — readthrough of the rendered README and LICENSE.