### PR TITLE
fix: ignore vendored grpc-go advisory with no upstream fix yet

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -15,3 +15,8 @@ CVE-2026-39822
 # terraform v1.15.8 - stdlib
 CVE-2026-27145
 CVE-2026-42504
+
+# gh v2.96.0 and terraform v1.15.8 - vendored google.golang.org/grpc
+# Fixed in grpc-go v1.82.1, but neither upstream has cut a release with the
+# bump yet. Re-evaluate whenever GH_VERSION or TERRAFORM_VERSION changes.
+GHSA-hrxh-6v49-42gf


### PR DESCRIPTION
fix: ignore vendored grpc-go advisory with no upstream fix yet
- gh v2.96.0 (grpc v1.81.1) and terraform v1.15.8 (grpc v1.80.0) are both the latest available releases of their respective tools, but neither has picked up the grpc-go v1.82.1 fix for GHSA-hrxh-6v49-42gf yet. There is nothing to bump in this repo, so add it to .trivyignore alongside the existing kubectl/terraform entries following the same re-evaluate-on-version-bump convention.